### PR TITLE
请升级org.mybatis:mybatis组件版本以解决1个安全漏洞

### DIFF
--- a/SSMdemo01/pom.xml
+++ b/SSMdemo01/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.mybatis</groupId>
             <artifactId>mybatis</artifactId>
-            <version>3.4.6</version>
+            <version>3.5.6</version>
         </dependency>
 
         <dependency>

--- a/mybatisdemo1/pom.xml
+++ b/mybatisdemo1/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.mybatis</groupId>
             <artifactId>mybatis</artifactId>
-            <version>3.4.6</version>
+            <version>3.5.6</version>
 
         </dependency>
 

--- a/mybatisdemo2/pom.xml
+++ b/mybatisdemo2/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.mybatis</groupId>
             <artifactId>mybatis</artifactId>
-            <version>3.4.6</version>
+            <version>3.5.6</version>
 
         </dependency>
 

--- a/springmvcdemo02/pom.xml
+++ b/springmvcdemo02/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.mybatis</groupId>
             <artifactId>mybatis</artifactId>
-            <version>3.4.6</version>
+            <version>3.5.6</version>
         </dependency>
 
         <dependency>

--- a/springmybatisdemo1/pom.xml
+++ b/springmybatisdemo1/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.mybatis</groupId>
             <artifactId>mybatis</artifactId>
-            <version>3.4.6</version>
+            <version>3.5.6</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
将 **org.mybatis:mybatis** 组件从3.4.6 版本升级至 3.5.6版本,
用于修复以下安全漏洞：


序号 | 漏洞编号 | 漏洞标题 | 漏洞级别
-- | -- | -- | --
1 | [MPS-2020-14133](https://www.oscs1024.com/hd/MPS-2020-14133) | MyBatis <3.5.6 存在反序列化漏洞 | 高危
  |   |   |   


<br/>

_注意 ：此 PR 由您（或拥有此仓库权限的其他维护者）授权 [墨菲安全](https://www.murphysec.com) 打开_

了解更多：
- [如何快速修复代码安全问题](https://www.murphysec.com/docs/faqs/security-issues/how-to-quick-fixes.html)
