### PR TITLE
请升级com.alibaba:druid组件版本以解决1个安全漏洞

### DIFF
--- a/SSMdemo01/pom.xml
+++ b/SSMdemo01/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>druid</artifactId>
-            <version>1.1.16</version>
+            <version>1.2.4</version>>
         </dependency>
 
         <dependency>

--- a/mybatisdemo2/pom.xml
+++ b/mybatisdemo2/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>druid</artifactId>
-            <version>1.1.16</version>
+            <version>1.2.4</version>>
         </dependency>
 
         <dependency>

--- a/springmvcdemo02/pom.xml
+++ b/springmvcdemo02/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>druid</artifactId>
-            <version>1.1.16</version>
+            <version>1.2.4</version>>
         </dependency>
         <!--
         spring操作jdbc的依赖,主要是操作数据库的

--- a/springmybatisdemo1/pom.xml
+++ b/springmybatisdemo1/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>druid</artifactId>
-            <version>1.1.16</version>
+            <version>1.2.4</version>>
         </dependency>
         <!--
         spring操作jdbc的依赖,主要是操作数据库的


### PR DESCRIPTION
将 **com.alibaba:druid** 组件从1.1.16 版本升级至 1.2.4版本,
用于修复以下安全漏洞：


序号 | 漏洞编号 | 漏洞标题 | 漏洞级别
-- | -- | -- | --
1 | [MPS-2021-25327](https://www.oscs1024.com/hd/MPS-2021-25327) | Alibaba Druid 目录遍历漏洞 | 高危
  |   |   |   


<br/>

_注意 ：此 PR 由您（或拥有此仓库权限的其他维护者）授权 [墨菲安全](https://www.murphysec.com) 打开_

了解更多：
- [如何快速修复代码安全问题](https://www.murphysec.com/docs/faqs/security-issues/how-to-quick-fixes.html)
